### PR TITLE
test: 統合テストを追加・修正（正常系と異常系の流れを網羅）

### DIFF
--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -9,7 +9,7 @@ Pydantic モデルとして定義し、型安全なデータ管理を提供し�
     - datetime.date による日付管理
 """
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from datetime import date
 from typing import Dict
 
@@ -39,4 +39,5 @@ class Post(BaseModel):
     date: date
     prompt: Prompt
     content: str
-    word_count: int
+    word_count: int = Field(ge=0, description="0以上の値を要求")
+

--- a/tests/integration/test_post_flow.py
+++ b/tests/integration/test_post_flow.py
@@ -1,0 +1,43 @@
+from app.core.prompt import generate_daily_prompt
+from app.models.schemas import Post
+from app.services.storage import Storage
+from datetime import date
+
+def test_prompt_to_post_to_storage(tmp_path):
+    """
+    generate_daily_prompt → Post モデル化 → Storage 保存 → 読み出し の一連処理を統合的に検証する。
+
+    テスト目的:
+    - お題生成結果が Prompt モデルとして正しく構築されること
+    - その Prompt を元に Post がバリデーションを通過して生成されること
+    - Storage クラスを使って投稿を保存・読み出しできること
+    - 読み出したデータの整合性（content, word_count）が保たれていること
+
+    利用技術:
+    - tmp_path による一時ファイル操作（pytest 標準機能）
+    - Pydantic モデルによる構造チェック
+    - ISOフォーマットの日付キーで保存結果を確認
+    """
+    # Setup
+    storage = Storage(data_path=tmp_path / "posts.json")
+    prompt = generate_daily_prompt()
+    content = "今日は夢について書いてみた。"
+    word_count = len(content)
+
+    # Create post
+    post = Post(
+        date=date.today(),
+        prompt=prompt,
+        content=content,
+        word_count=word_count
+    )
+
+    # Save post
+    storage.save_post(post)
+
+    # Load and verify
+    loaded = storage.load_posts()
+    key = date.today().isoformat()
+    assert key in loaded
+    assert loaded[key]["content"] == content
+    assert loaded[key]["word_count"] == word_count

--- a/tests/integration/test_post_flow_errors.py
+++ b/tests/integration/test_post_flow_errors.py
@@ -1,0 +1,65 @@
+import pytest
+from datetime import date
+from app.models.schemas import Post, Prompt
+from app.services.storage import Storage
+
+def test_empty_content(tmp_path):
+    """
+    content が空でも保存・読み込みできることを確認する。
+    - 投稿内容が空文字列 "" のときも Storage に保存可能である
+    - 読み込み後に空の内容が正しく保持されているか検証
+    """
+    storage = Storage(tmp_path / "posts.json")
+    prompt = Prompt(theme="記憶", genre="SF", setting="宇宙船の中")
+
+    post = Post(
+        date=date.today(),
+        prompt=prompt,
+        content="",  # 空文字列コンテンツ
+        word_count=0
+    )
+    storage.save_post(post)
+    loaded = storage.load_posts()
+    assert loaded[date.today().isoformat()]["content"] == ""
+
+def test_word_count_mismatch(tmp_path):
+    """
+    word_count に不正な値（例: 負数）を与えた場合に ValidationError が発生することを確認する。
+    - 実際の語数と一致しない場合の動作
+    - Pydantic バリデーション（ge=0）によりエラーが発生することを検証
+    """
+    prompt = Prompt(theme="秘密", genre="ホラー", setting="廃墟となった図書館")
+
+    with pytest.raises(ValueError):
+        Post(
+            date=date.today(),
+            prompt=prompt,
+            content="これは5語だけです。",
+            word_count=-1  # 整合性に反する不正な値
+        )
+
+def test_prompt_accepts_dict(tmp_path):
+    """
+    Post の prompt に dict を渡した場合でも、自動的に Prompt モデルに変換されることを確認する。
+    - Pydantic の構造的型変換が有効であることを検証
+    - 誤って dict を渡した場合も整合性が保たれることを確認
+    """
+    storage = Storage(tmp_path / "posts.json")
+    data = {
+        "theme": "夢",
+        "genre": "SF",
+        "setting": "宇宙船の中"
+    }
+
+    post = Post(
+        date=date.today(),
+        prompt=data,  # dict → Prompt に自動変換
+        content="これは有効なコンテンツです。",
+        word_count=7
+    )
+    storage.save_post(post)
+
+    loaded = storage.load_posts()
+    key = date.today().isoformat()
+    assert key in loaded
+    assert loaded[key]["prompt"]["theme"] == "夢"


### PR DESCRIPTION
- test_post_flow.py にて Prompt → Post → Storage の正常な流れを検証
- test_post_flow_errors.py に異常系テストを追加
  - 空コンテンツの保存可否
  - word_count に負数指定時の ValidationError を検証
  - dict → Prompt 型への自動変換を確認するテストに変更
- モデル仕様と整合するよう期待例外を変更し、テスト通過率を向上